### PR TITLE
changed environment vars to postgres standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Of course, before that we need to do some additional configuration:
 - PostgreSQL must be set up with 2 databases named `nmebious` and `test` (the second one is optional and only needed if you want to run the test suite).
 - Create a `.env` file with the following format:
 	```
-   DB_USER=user
-   DB_PASS=password
+   PGUSER=user
+   PGPASSWORD=password
    SECRET=secret
    	```
-  Where `DB_USER` and `DB_PASS` are the credentials for the Postgres database, and `SECRET` is the key used by HMAC to hash the IP addresses.
+  Where `PGUSER` and `PGPASSWORD` are the credentials for the Postgres database, and `SECRET` is the key used by HMAC to hash the IP addresses.
 
 - [ImageMagick](https://imagemagick.org/) needs to be installed.
 

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -38,10 +38,10 @@
 (defparameter *env* (read-env (asdf:system-relative-pathname 'nmebious ".env")))
 
 ;; Postgres user
-(defparameter *db-user* (gethash "DB_USER" *env*))
+(defparameter *db-user* (gethash "PGUSER" *env*))
 
 ;; Postgres password
-(defparameter *db-pass* (gethash "DB_PASS" *env*))
+(defparameter *db-pass* (gethash "PGPASSWORD" *env*))
 
 ;; HMAC secret
 (defparameter *secret* (gethash "SECRET" *env*))


### PR DESCRIPTION
Changed "DB_USER" to "PGUSER" and "DB_PASS" to "PGPASSWORD", as per postgres standard naming (https://www.postgresql.org/docs/9.3/libpq-envars.html). Updated README to reflect these changes.