### PR TITLE
HTML escaping for text posts before entry in DB

### DIFF
--- a/templates/mebious.html
+++ b/templates/mebious.html
@@ -42,7 +42,7 @@
       {% endifequal %}
       <div id="posts">
          {% for text in text-posts %}
-            <p class="post" style="{{ text.style }}">{{ text.data }}</p>
+            <p class="post" style="{{ text.style }}">{{ text.data|safe }}</p>
          {% endfor %}
       </div>
       {% for file in file-posts %}


### PR DESCRIPTION
Replaced djula's auto-escaping on template rendering with a manual escaping before the post is committed to the DB.