### PR TITLE
Actually properly start the server when using Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ run:
 	$(LISP) --load nmebious.asd \
 	     	--eval '(ql:quickload :nmebious)' \
 	     	--eval '(in-package :nmebious)' \
-	     	--eval '(start-server)'
+	     	--eval '(main)'


### PR DESCRIPTION
I have chosen to remove the `&rest args` in the `main` function as it was discarded anyways.

It has been replaced with a single argument, `swank`, which is optional and defaults to `nil`. This variable controls if swank is started along with the server or not